### PR TITLE
Remove `long` for python3 compat

### DIFF
--- a/exporters/SimpleEval.py
+++ b/exporters/SimpleEval.py
@@ -24,6 +24,7 @@ import shlex
 import string
 
 from decimal import Decimal
+from others.py3compat import *
 
 #-------------------------------------------------------------------------------
 __version__ = '1.0'

--- a/exporters/base_support.py
+++ b/exporters/base_support.py
@@ -7,6 +7,7 @@ import shlex
 import sqlite3
 import itertools
 import ConfigParser
+from others.py3compat import *
 
 from threading import current_thread
 from terminalsize import get_terminal_size

--- a/ml/pigaios_create_dataset.py
+++ b/ml/pigaios_create_dataset.py
@@ -9,6 +9,7 @@ import json
 import time
 import sqlite3
 import numpy as np
+from others.py3compat import *
 
 #-------------------------------------------------------------------------------
 _DEBUG = False
@@ -135,7 +136,7 @@ class CPigaiosTrainer:
 
       if field == "switchs_json":
         ret[field] = int(row["src_%s" % field] == row["bin_%s" % field])
-      elif type(row["src_%s" % field]) in [int, long]:
+      elif type(row["src_%s" % field]) in integer_types:
         ret["src_%s" % field] = int(row["src_%s" % field])
         ret["bin_%s" % field] = int(row["bin_%s" % field])
         ret["%s_diff" % field] = abs(row["src_%s" % field] - row["bin_%s" % field])

--- a/others/py3compat.py
+++ b/others/py3compat.py
@@ -1,0 +1,6 @@
+# Workaround for Python3 compat
+try
+  integer_types = (int, long)
+except NameError:
+  long = int
+  integer_types = (int,)

--- a/sourceimp_core.py
+++ b/sourceimp_core.py
@@ -7,6 +7,7 @@ import json
 import time
 import difflib
 import sqlite3
+from others.py3compat import *
 
 try:
   from sourcexp_ida import log
@@ -157,7 +158,7 @@ class CBinaryToSourceImporter:
 
       if field == "switchs_json":
         ret[field] = int(src_row[field] == bin_row[field])
-      elif type(src_row[field]) in [int, long]:
+      elif type(src_row[field]) in integer_types:
         ret["src_%s" % field] = int(src_row[field])
         ret["bin_%s" % field] = int(bin_row[field])
         ret[field] = abs(src_row[field] - bin_row[field])
@@ -244,7 +245,7 @@ class CBinaryToSourceImporter:
       if src_row[field] == bin_row[field] and field == "name":
         score += 3 * len(fields)
         reasons.append("Same function name")
-      elif type(src_row[field]) in [int, long]:
+      elif type(src_row[field]) in integer_types:
         if src_row[field] == bin_row[field]:
           score += 1.1
           non_zero_num_matches += int(src_row[field] != 0)

--- a/sourceimp_ida.py
+++ b/sourceimp_ida.py
@@ -8,6 +8,7 @@ import shlex
 import difflib
 import sqlite3
 import operator
+from others.py3compat import *
 
 from subprocess import Popen, PIPE, STDOUT
 


### PR DESCRIPTION
Proposed a change for python3 compatibility improvement. #17 
Idea was to make as few changes as possible.
Added the new module in `others` folder because I thought it was the most suitable for this (might be better to move it to a different one?)