### PR TITLE
Fix undefined names in Python 3

### DIFF
--- a/exporters/SimpleEval.py
+++ b/exporters/SimpleEval.py
@@ -25,6 +25,17 @@ import string
 
 from decimal import Decimal
 
+try:
+  long        # Python 2
+except NameError:
+  long = int  # Python 3
+
+try:
+  raw_input          # Python 2
+except NameError:
+  raw_input = input  # Python 3
+
+
 #-------------------------------------------------------------------------------
 __version__ = '1.0'
 __all__ = [

--- a/exporters/base_support.py
+++ b/exporters/base_support.py
@@ -86,7 +86,7 @@ def constant_filter(value):
     return False
 
   #no single bits sets - mostly defines / flags
-  for i in xrange(64):
+  for i in range(64):
     if value == (1 << i):
       return False
 
@@ -681,4 +681,3 @@ class CBaseExporter(object):
 
   def export_one(self, filename, args, is_c):
     raise Exception("Not implemented in the inherited class")
-

--- a/exporters/kfuzzy.py
+++ b/exporters/kfuzzy.py
@@ -18,6 +18,7 @@ You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 """
+from __future__ import print_function
 
 import os
 import sys
@@ -36,6 +37,12 @@ try:
     psyco.full()
 except ImportError:
     pass
+
+try:
+  xrange          # Python 2
+except NameError:
+  xrange = range  # Python 3
+
 
 class CFileStr(str):
     fd = None
@@ -269,13 +276,13 @@ class CKoretFuzzyHashing:
         return hash1 + ";" + hash2 + ";" + hash3
 
     def hash_file(self, filename, aggresive = False):
-        f = file(filename, "rb")
+        f = open(filename, "rb")
         f.seek(0, 2)
         size = f.tell()
         
         if size > self.big_file_size:
-            print
-            print "Warning! Support for big files (%d MB > %d MB) is broken!" % (size/1024/1024, self.big_file_size / 1024 / 1024)
+            print()
+            print("Warning! Support for big files (%d MB > %d MB) is broken!" % (size/1024/1024, self.big_file_size / 1024 / 1024))
             fbytes = CFileStr(f)
         else:
             f.seek(0)
@@ -331,27 +338,27 @@ class ksha(kdha):
         self._kfd.algorithm = self._kfd.simplified
 
 def usage():
-    print "Usage:", sys.argv[0], "<filename>"
+    print("Usage:", sys.argv[0], "<filename>")
 
 def main(path):
     hash = CKoretFuzzyHashing()
     #hash.algorithm = hash._fast_hash
     
     if os.path.isdir(path):
-        print "Signature;Simple Signature;Reverse Signature;Filename"
+        print("Signature;Simple Signature;Reverse Signature;Filename")
         for root, dirs, files in os.walk(path):
             for name in files:
                 tmp = os.path.join(root, name)
                 try:
                     ret = hash.hash_file(tmp, True)
-                    print "%s;%s" % (ret, tmp)
+                    print("%s;%s" % (ret, tmp))
                 except:
-                    print "***ERROR with file %s" % tmp
-                    print sys.exc_info()[1]
+                    print("***ERROR with file %s" % tmp)
+                    print(sys.exc_info()[1])
     else:
         hash = CKoretFuzzyHashing()
         ret = hash.hash_file(path, True)
-        print "%s;%s" % (path, ret)
+        print("%s;%s" % (path, ret))
 
 if __name__ == "__main__":
     if len(sys.argv) == 1:

--- a/exporters/simple_macro_parser.py
+++ b/exporters/simple_macro_parser.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import os
 import re
 import sys
@@ -7,6 +8,11 @@ import decimal
 
 from SimpleEval import SimpleEval
 from kfuzzy import CKoretFuzzyHashing
+
+try:
+  long        # Python 2
+except NameError:
+  long = int  # Python 3
 
 #-------------------------------------------------------------------------------
 MACROS_REGEXP = '\W*#\W*define\W+([a-z0-9_]+)\W+([a-z0-9_]+)'
@@ -104,7 +110,7 @@ class CMacroExtractor:
 
 #-------------------------------------------------------------------------------
 def usage():
-  print "Usage: %s <source file>" % sys.argv[0]
+  print("Usage: %s <source file>" % sys.argv[0])
 
 #-------------------------------------------------------------------------------
 def main(filename):
@@ -112,8 +118,8 @@ def main(filename):
   enums = extractor.extract(filename)
   for name in enums:
     src = enums[name]
-    print src
-    print
+    print(src)
+    print()
 
 if __name__ == "__main__":
   if len(sys.argv) == 1:

--- a/ml/pigaios_create_dataset.py
+++ b/ml/pigaios_create_dataset.py
@@ -10,13 +10,11 @@ import time
 import sqlite3
 import numpy as np
 
-#-------------------------------------------------------------------------------
-# Hack for Python3 compat
 try:
-  INTEGER_TYPES = (int, long)
+  long        # Python 2
 except NameError:
-  long = int
-  INTEGER_TYPES = (int,)
+  long = int  # Python 3
+
 
 #-------------------------------------------------------------------------------
 _DEBUG = False
@@ -143,7 +141,7 @@ class CPigaiosTrainer:
 
       if field == "switchs_json":
         ret[field] = int(row["src_%s" % field] == row["bin_%s" % field])
-      elif type(row["src_%s" % field]) in INTEGER_TYPES:
+      elif type(row["src_%s" % field]) in (int, long):
         ret["src_%s" % field] = int(row["src_%s" % field])
         ret["bin_%s" % field] = int(row["bin_%s" % field])
         ret["%s_diff" % field] = abs(row["src_%s" % field] - row["bin_%s" % field])
@@ -243,4 +241,3 @@ if __name__ == "__main__":
     main(sys.argv[1], sys.argv[2], sys.argv[3])
   else:
     usage()
-

--- a/sourceimp_core.py
+++ b/sourceimp_core.py
@@ -11,6 +11,11 @@ import sqlite3
 from others.py3compat import INTEGER_TYPES
 
 try:
+  reload           # Python 2
+except NameError:  # Python 3
+  from importlib import reload
+
+try:
   from sourcexp_ida import log
   from_ida = True
 except ImportError:
@@ -27,6 +32,11 @@ try:
   has_ml = True
 except ImportError:
   has_ml = False
+
+try:
+  long        # Python 2
+except NameError:
+  long = int  # Python 3
 
 #-----------------------------------------------------------------------
 def sourceimp_log(msg):
@@ -851,4 +861,3 @@ class CBinaryToSourceImporter:
       if tmp_id != src_id:
         if _DEBUG: self.dubious_matches[src_id] = self.best_matches[src_id]
         del self.best_matches[src_id]
-

--- a/sourceimp_ida.py
+++ b/sourceimp_ida.py
@@ -18,6 +18,12 @@ from idaapi import (Choose2, PluginForm, Form, init_hexrays_plugin, load_plugin,
                     reg_write_string)
 
 import sourceimp_core
+
+try:
+  reload           # Python 2
+except NameError:  # Python 3
+  from importlib import reload
+
 reload(sourceimp_core)
 
 from sourceimp_core import *
@@ -564,4 +570,3 @@ if __name__ == "__main__":
       raise
   finally:
     hide_wait_box()
-


### PR DESCRIPTION
__reload()__ was moved in Python 3 and __file()__, __long__, __raw_input()__, and __xrange()__ were removed and __print()__ became a function.  This PR proposes fixes that provide equivalent functionality in both Python 2 and Python 3.

Before this PR: [flake8](http://flake8.pycqa.org) testing of https://github.com/joxeankoret/pigaios on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./sourceimp_core.py:24:3: F821 undefined name 'reload'
  reload(pigaios_ml)
  ^
./sourceimp_core.py:383:10: F821 undefined name 'long'
    ea = long(bin_row["ea"])
         ^
./sourceimp_core.py:458:19: F821 undefined name 'long'
        func_ea = long(row[0])
                  ^
./sourceimp_core.py:490:17: F821 undefined name 'long'
      func_ea = long(row[0])
                ^
./sourceimp_core.py:518:17: F821 undefined name 'long'
      func_ea = long(row[0])
                ^
./sourceimp_core.py:702:43: F821 undefined name 'long'
            log(msg % (call_type, src_id, long(bin_ea), row["name"], len(bin_rows) * len(src_rows)))
                                          ^
./sourceimp_core.py:714:34: F821 undefined name 'long'
                  self.add_match(long(src_row[call_type]), bin_row[call_type],
                                 ^
./sourceimp_core.py:728:18: F821 undefined name 'long'
        bin_id = long(row["id"])
                 ^
./sourceimp_core.py:819:46: F821 undefined name 'long'
      bin_func_name = self.get_function_name(long(ea))
                                             ^
./sourceimp_ida.py:21:1: F821 undefined name 'reload'
reload(sourceimp_core)
^
./exporters/SimpleEval.py:112:14: F821 undefined name 'long'
      tmp1 = long(val1)
             ^
./exporters/SimpleEval.py:113:14: F821 undefined name 'long'
      tmp2 = long(val2)
             ^
./exporters/SimpleEval.py:117:14: F821 undefined name 'long'
      tmp1 = long(val1)
             ^
./exporters/SimpleEval.py:118:14: F821 undefined name 'long'
      tmp2 = long(val2)
             ^
./exporters/SimpleEval.py:122:14: F821 undefined name 'long'
      tmp1 = long(val1)
             ^
./exporters/SimpleEval.py:123:14: F821 undefined name 'long'
      tmp2 = long(val2)
             ^
./exporters/SimpleEval.py:127:14: F821 undefined name 'long'
      tmp1 = long(val1)
             ^
./exporters/SimpleEval.py:128:14: F821 undefined name 'long'
      tmp2 = long(val2)
             ^
./exporters/SimpleEval.py:162:15: F821 undefined name 'long'
      token = long(token, 16)
              ^
./exporters/SimpleEval.py:164:15: F821 undefined name 'long'
      token = long(token, 8)
              ^
./exporters/SimpleEval.py:251:11: F821 undefined name 'raw_input'
    cmd = raw_input("C expr> ")
          ^
./exporters/kfuzzy.py:278:77: E999 SyntaxError: invalid syntax
            print "Warning! Support for big files (%d MB > %d MB) is broken!" % (size/1024/1024, self.big_file_size / 1024 / 1024)
                                                                            ^
./exporters/simple_macro_parser.py:107:33: E999 SyntaxError: invalid syntax
  print "Usage: %s <source file>" % sys.argv[0]
                                ^
./exporters/base_support.py:89:12: F821 undefined name 'xrange'
  for i in xrange(64):
           ^
2     E999 SyntaxError: invalid syntax
22    F821 undefined name 'long'
24
```