### PR TITLE
Add Python 3 support to srcbindiff.py

### DIFF
--- a/exporters/base_support.py
+++ b/exporters/base_support.py
@@ -25,10 +25,13 @@ import json
 import shlex
 import sqlite3
 import itertools
-import ConfigParser
+try:
+  import configparser
+except ImportError:
+  import ConfigParser as configparser
 
 from threading import current_thread
-from terminalsize import get_terminal_size
+from .terminalsize import get_terminal_size
 
 from threading import Lock
 from multiprocessing.pool import Pool
@@ -183,7 +186,9 @@ def all_combinations(items):
 
 #-------------------------------------------------------------------------------
 def json_loads(line):
-  return json.loads(line.decode("utf-8","ignore"))
+  if sys.version_info < (3, 0) or line is bytes:
+    line = line.decode("utf-8", "ignore")
+  return json.loads(line)
 
 #-------------------------------------------------------------------------------
 def _pickle_method(method):
@@ -203,15 +208,18 @@ def _unpickle_method(func_name, obj, cls):
 
   return func.__get__(obj, cls)
 
-import copy_reg
+try:
+  import copyreg
+except:
+  import copy_reg as copyreg
 import types
-copy_reg.pickle(types.MethodType, _pickle_method, _unpickle_method)
+copyreg.pickle(types.MethodType, _pickle_method, _unpickle_method)
 
 #-------------------------------------------------------------------------------
 class CBaseExporter(object):
   def __init__(self, cfg_file):
     self.cfg_file = cfg_file
-    self.config = ConfigParser.ConfigParser()
+    self.config = configparser.ConfigParser()
     self.config.optionxform = str
     self.config.read(cfg_file)
     self.db = {}

--- a/exporters/clang_exporter.py
+++ b/exporters/clang_exporter.py
@@ -25,9 +25,9 @@ from threading import current_thread
 import clang.cindex
 from clang.cindex import Diagnostic, CursorKind, TokenKind
 
-from base_support import *
-from SimpleEval import simple_eval
-from simple_macro_parser import CMacroExtractor
+from .base_support import *
+from .SimpleEval import simple_eval
+from .simple_macro_parser import CMacroExtractor
 
 #-------------------------------------------------------------------------------
 CONDITIONAL_OPERATORS = ["==", "!=", "<", ">", ">=", "<=", "?"]
@@ -360,8 +360,8 @@ class CLangParser:
 
       # Same as before but we pass to the member any literal expression.
       method_name = 'visit_LITERAL'
-      if children.kind >= CursorKind.INTEGER_LITERAL and \
-           children.kind <= CursorKind.STRING_LITERAL:
+      if children.kind.value >= CursorKind.INTEGER_LITERAL.value and \
+           children.kind.value <= CursorKind.STRING_LITERAL.value:
         if method_name in dir(obj):
           func = getattr(obj, method_name)
           if func(children):
@@ -386,7 +386,7 @@ class CClangExporter(CBaseExporter):
     start_loc = cursor.location
     filename = start_loc.file.name
     if filename not in self.source_cache:
-      self.source_cache[filename] = open(filename, "rb").readlines()
+      self.source_cache[filename] = open(filename, "r").readlines()
 
     source = "".join(self.source_cache[filename][start_line-1:end_line])
     return source

--- a/exporters/kfuzzy.py
+++ b/exporters/kfuzzy.py
@@ -24,7 +24,10 @@ import os
 import sys
 import base64
 
-from itertools import imap
+try:
+	from itertools import imap
+except ImportError:
+    imap = map
 
 try:
     from fasttoad_wrap import modsum

--- a/exporters/simple_macro_parser.py
+++ b/exporters/simple_macro_parser.py
@@ -24,8 +24,8 @@ import re
 import sys
 import decimal
 
-from SimpleEval import SimpleEval
-from kfuzzy import CKoretFuzzyHashing
+from .SimpleEval import SimpleEval
+from .kfuzzy import CKoretFuzzyHashing
 
 try:
   long        # Python 2
@@ -34,6 +34,8 @@ except NameError:
 
 #-------------------------------------------------------------------------------
 MACROS_REGEXP = '\W*#\W*define\W+([a-z0-9_]+)\W+([a-z0-9_]+)'
+if sys.version_info >= (3, 0):
+  MACROS_REGEXP = MACROS_REGEXP.encode("ascii")
 DEFAULT_ENUM = ""
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
I used the zlib example from the readme to compare the following scenarios: Before these changes with Python 2, after these changes with Python 2 and after these changes with Python 3.
Both Python 2 cases gave the exact same sqlite database.
Python 3 was different, but there seem to be only differences in how ids are assigned, as well as the order of elements in JSON, which is probably because of changes in the implementations of set and dict.

The only changes I am not 100% sure about yet are these two:
https://github.com/joxeankoret/pigaios/pull/29/files#diff-896ceb413e77f27a034b3e24c53ab2c2R389
https://github.com/joxeankoret/pigaios/pull/29/files#diff-02b63b7451c485af3b9682e4c0059d6cR105
Why are you opening these files in binary mode? Both the source and the project file are text files, so this doesn't make much sense to me. In Python 3 this makes a difference because of str vs. bytes.