### PR TITLE
patch for python 3.10, LLVM-14, IDA 7.7

### DIFF
--- a/exporters/SimpleEval.py
+++ b/exporters/SimpleEval.py
@@ -42,17 +42,6 @@ import string
 
 from decimal import Decimal
 
-try:
-  long        # Python 2
-except NameError:
-  long = int  # Python 3
-
-try:
-  raw_input          # Python 2
-except NameError:
-  raw_input = input  # Python 3
-
-
 #-------------------------------------------------------------------------------
 __version__ = '1.0'
 __all__ = [
@@ -137,23 +126,23 @@ class SimpleEval:
     elif op == "*":
       result *= val2
     elif op == "<<":
-      tmp1 = long(val1)
-      tmp2 = long(val2)
+      tmp1 = int(val1)
+      tmp2 = int(val2)
       tmp1 <<= tmp2
       result = Decimal(tmp1)
     elif op == ">>":
-      tmp1 = long(val1)
-      tmp2 = long(val2)
+      tmp1 = int(val1)
+      tmp2 = int(val2)
       tmp1 >>= tmp2
       result = Decimal(tmp1)
     elif op == "|":
-      tmp1 = long(val1)
-      tmp2 = long(val2)
+      tmp1 = int(val1)
+      tmp2 = int(val2)
       tmp1 |= tmp2
       result = Decimal(tmp1)
     elif op == "&":
-      tmp1 = long(val1)
-      tmp2 = long(val2)
+      tmp1 = int(val1)
+      tmp2 = int(val2)
       tmp1 &= tmp2
       result = Decimal(tmp1)
     elif op == "**":
@@ -187,9 +176,9 @@ class SimpleEval:
     if token.startswith("0x"):
       if token.endswith(".0"):
         token = token.rstrip(".0")
-      token = long(token, 16)
+      token = int(token, 16)
     elif token[0] == "0" and len(token) == 1 and token.find(".") == -1:
-      token = long(token, 8)
+      token = int(token, 8)
 
     return Decimal(token)
 
@@ -276,7 +265,7 @@ def main():
 
   evaluator = SimpleEval()
   while 1:
-    cmd = raw_input("C expr> ")
+    cmd = input("C expr> ")
     if cmd.lower() in exit_cmds:
       break
     elif cmd == "":

--- a/exporters/clang_exporter.py
+++ b/exporters/clang_exporter.py
@@ -360,8 +360,8 @@ class CLangParser:
 
       # Same as before but we pass to the member any literal expression.
       method_name = 'visit_LITERAL'
-      if children.kind >= CursorKind.INTEGER_LITERAL and \
-           children.kind <= CursorKind.STRING_LITERAL:
+      if children.kind.value >= CursorKind.INTEGER_LITERAL.value and \
+           children.kind.value <= CursorKind.STRING_LITERAL.value:
         if method_name in dir(obj):
           func = getattr(obj, method_name)
           if func(children):
@@ -386,7 +386,7 @@ class CClangExporter(CBaseExporter):
     start_loc = cursor.location
     filename = start_loc.file.name
     if filename not in self.source_cache:
-      self.source_cache[filename] = open(filename, "rb").readlines()
+      self.source_cache[filename] = open(filename, "r").readlines()
 
     source = "".join(self.source_cache[filename][start_line-1:end_line])
     return source
@@ -405,7 +405,7 @@ class CClangExporter(CBaseExporter):
 
   def strip_macros(self, filename):
     ret = []
-    for line in open(filename, "rb").readlines():
+    for line in open(filename, "r").readlines():
       line = line.strip("\r").strip("\n")
       if line.find("#include") == -1 and line.strip(" ").strip("\t").strip(" ").startswith("#"):
         ret.append("// stripped: %s" % line)

--- a/exporters/kfuzzy.py
+++ b/exporters/kfuzzy.py
@@ -24,25 +24,17 @@ import os
 import sys
 import base64
 
-from itertools import imap
-
 try:
     from fasttoad_wrap import modsum
 except:
     def modsum(buf):
-        return sum(imap(ord, buf)) % 255
+        return sum(map(ord, buf)) % 255
 
 try:
     import psyco
     psyco.full()
 except ImportError:
     pass
-
-try:
-  xrange          # Python 2
-except NameError:
-  xrange = range  # Python 3
-
 
 class CFileStr(str):
     fd = None
@@ -84,7 +76,7 @@ class CKoretFuzzyHashing:
         m = max(len(sign1), len(sign2))
         distance = 0
         
-        for c in xrange(0, m):
+        for c in range(0, m):
             if sign1[c:c+1] != sign2[c:c+1]:
                 distance += 1
         
@@ -99,9 +91,9 @@ class CKoretFuzzyHashing:
         buf = []
         reduce_errors = self.reduce_errors
         # Adjust the output to the desired output size
-        for c in xrange(0, output_size):
+        for c in range(0, output_size):
             tmp = bytes[c*size:(c*size+1)+bsize]
-            ret = sum(imap(ord, tmp)) % 255
+            ret = sum(map(ord, tmp)) % 255
             if reduce_errors:
                 if ret != 255 and ret != 0:
                     buf.append(chr(ret))
@@ -143,11 +135,10 @@ class CKoretFuzzyHashing:
                 break
         
         ret = "".join(ret)
-        size = len(ret) / output_size
+        size = round(len(ret) / output_size)    # avoid fraction
         buf = []
-        
         # Adjust the output to the desired output size
-        for c in xrange(0, output_size):
+        for c in range(0, output_size):
             if aggresive:
                 buf.append(ret[c:c+size+1][ignore_range:ignore_range+1])
             else:
@@ -164,7 +155,7 @@ class CKoretFuzzyHashing:
             
         ret = "".join(buf)
         
-        return base64.b64encode(ret).strip("=")[:output_size]
+        return base64.b64encode(ret.encode()).strip(b"=")[:output_size]
 
     def _fast_hash(self, bytes, aggresive = False):
         i = -1
@@ -178,7 +169,7 @@ class CKoretFuzzyHashing:
         while i < output_size:
             i += 1
             buf = bytes[i*bsize:(i+1)*bsize]
-            char = sum(imap(ord, buf)) % 255
+            char = sum(map(ord, buf)) % 255
             if self.reduce_errors:
                 if char != 255 and char != 0:
                     radd(chr(char))
@@ -214,7 +205,7 @@ class CKoretFuzzyHashing:
                 val = output_size
             
             buf = bytes[chunk_size:chunk_size+val]
-            byte = self.xor(imap(ord, buf)) % 255
+            byte = self.xor(map(ord, buf)) % 255
             byte = chr(byte)
             
             if byte != '\xff' and byte != '\x00':
@@ -225,7 +216,7 @@ class CKoretFuzzyHashing:
         ret = "".join(ret)
         buf = ""
         size = len(ret)/output_size
-        for n in xrange(0, output_size):
+        for n in range(0, output_size):
             buf += ret[n*size:(n*size)+1]
         
         return base64.b64encode(buf).strip("=")[:output_size]
@@ -273,7 +264,7 @@ class CKoretFuzzyHashing:
         hash2 = func(bytes, aggresive)
         hash3 = func(bytes[::-1], aggresive)
         
-        return hash1 + ";" + hash2 + ";" + hash3
+        return hash1.decode() + ";" + hash2.decode() + ";" + hash3.decode()
 
     def hash_file(self, filename, aggresive = False):
         f = open(filename, "rb")

--- a/exporters/simple_macro_parser.py
+++ b/exporters/simple_macro_parser.py
@@ -27,11 +27,6 @@ import decimal
 from SimpleEval import SimpleEval
 from kfuzzy import CKoretFuzzyHashing
 
-try:
-  long        # Python 2
-except NameError:
-  long = int  # Python 3
-
 #-------------------------------------------------------------------------------
 MACROS_REGEXP = '\W*#\W*define\W+([a-z0-9_]+)\W+([a-z0-9_]+)'
 DEFAULT_ENUM = ""
@@ -91,7 +86,7 @@ class CMacroExtractor:
         if type(d[element]) is decimal.Decimal:
           eng_str = d[element].to_eng_string()
           if str(eng_str).find(".") == -1:
-            value = "0x%08x" % long(eng_str)
+            value = "0x%08x" % int(eng_str)
 
         if value is None:
           value = str(d[element])
@@ -106,7 +101,7 @@ class CMacroExtractor:
 
   def extract(self, filename):
     self.filename = filename
-    return self.extract_from_buffer(open(filename, "rb").read())
+    return self.extract_from_buffer(open(filename, "r").read())
 
   def extract_from_buffer(self, buf):
     ret = {}

--- a/sourceimp_ida.py
+++ b/sourceimp_ida.py
@@ -73,7 +73,7 @@ def indent_source(src):
   try:
     p = Popen(indent_cmd, stdout=PIPE, stdin=PIPE, stderr=STDOUT)
     indenter = p.communicate(input=src)[0]
-    tmp = indenter.decode()
+    tmp = indenter
     if tmp != "" and tmp is not None:
       tmp = tmp.replace("<", "&lt;").replace(">", "&gt;")
       return tmp
@@ -335,11 +335,13 @@ class CDiffChooser(Choose):
     return n
 
   def OnSelectLine(self, n):
+    n = n[0]
     self.selcount += 1
     row = self.items[n]
     ea = long(row[3], 16)
-    if isEnabled(ea):
-      jumpto(ea)
+    jumpto(ea)
+    # if isEnabled(ea):
+    #   jumpto(ea)
 
   def OnSelectionChange(self, sel_list):
     self.selected_items = sel_list
@@ -406,7 +408,7 @@ class CDiffChooser(Choose):
         Warning("Cannot decompile function 0x%08x" % ea)
         return False
 
-      buf1 = indent_source(row[0].decode("utf-8", "ignore"))
+      buf1 = indent_source(row[0])
       buf2 = proto
       buf2 += u"\n".join(self.differ.pseudo[ea])
       new_buf = indent_source(buf2)

--- a/srcbindiff.py
+++ b/srcbindiff.py
@@ -22,9 +22,10 @@ from __future__ import print_function
 
 import os
 import sys
-import popen2
-import ConfigParser
+import configparser
 
+### to solve importing problem in windows
+# sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from exporters.base_support import is_source_file, is_header_file
 
 try:
@@ -53,7 +54,7 @@ class CSBDProject:
 
   def resolve_clang_includes(self):
     cmd = "clang -print-file-name=include"
-    rfd, wfd = popen2.popen2(cmd)
+    rfd = os.popen(cmd)
     return rfd.read().strip("\n")
 
   def create_project(self, path, project_file):
@@ -61,7 +62,7 @@ class CSBDProject:
       print("Project file %s already exists." % repr(project_file))
       return False
 
-    config = ConfigParser.RawConfigParser()
+    config = configparser.RawConfigParser()
     config.optionxform = str
 
     # Add the CLang specific configuration section
@@ -96,7 +97,7 @@ class CSBDProject:
             filename = '"%s"' % filename
           config.set(section, filename, "1")
 
-    with open(project_file, "wb") as configfile:
+    with open(project_file, "w") as configfile:
       configfile.write("#"*len(SBD_PROJECT_COMMENT) + "\n")
       configfile.write(SBD_PROJECT_COMMENT + "\n")
       configfile.write("#"*len(SBD_PROJECT_COMMENT) + "\n")


### PR DESCRIPTION
Here I set up env: kali-rolling, python 3.10, LLVM-14, IDA 7.7, operated according to README and met some errors.
Most errors come from changes between py2 and py3, like library/API name changing, and misuse of bytes/str.
Some are only found by `--no-parallel` and removing "try-catch" to test, like SQLite connection cannot be pickled for parallel in py3.

I modified each place reporting error, migrating to py3 and removed codes supporting py2, not sure if it is ok.
This patch works in my env to generate `sbd.project` and `*.sqlite`, and available for matching:
```bash
$ python srcbindiff.py -create
Project file 'sbd.project' already exists.

$ python srcbindiff.py --no-parallel -export    # parallel also work
[i] Removing existing file zlib-1.2.13.sqlite
[+] CC contrib/blast/blast.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -..
[+] CC contrib/infback9/infback9.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include..
[+] CC contrib/infback9/inftree9.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include..
[+] CXX contrib/iostream/test.cpp -I/usr/lib/llvm-14/lib/clang/14.0.6/include ..
contrib/iostream/zfstream.h:5,10: fatal: 'fstream.h' file not found
[+] CXX contrib/iostream/zfstream.cpp -I/usr/lib/llvm-14/lib/clang/14.0.6/incl..
contrib/iostream/zfstream.h:5,10: fatal: 'fstream.h' file not found
[+] CXX contrib/iostream2/zstream_test.cpp -I/usr/lib/llvm-14/lib/clang/14.0.6..
contrib/iostream2/zstream.h:27,10: fatal: 'strstream.h' file not found
[+] CXX contrib/iostream3/test.cc -I/usr/lib/llvm-14/lib/clang/14.0.6/include ..
[+] CXX contrib/iostream3/zfstream.cc -I/usr/lib/llvm-14/lib/clang/14.0.6/incl..
[+] CC contrib/minizip/ioapi.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I...
[+] CC contrib/minizip/iowin32.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -..
contrib/minizip/iowin32.h:14,10: fatal: 'windows.h' file not found
[+] CC contrib/minizip/miniunz.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -..
[+] CC contrib/minizip/minizip.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -..
[+] CC contrib/minizip/mztools.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -..
[+] CC contrib/minizip/unzip.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I...
[+] CC contrib/minizip/zip.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -..
[+] CC contrib/puff/puff.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I...
[+] CC contrib/puff/pufftest.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I...
[+] CC contrib/testzlib/testzlib.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include..
contrib/testzlib/testzlib.c:3,10: fatal: 'windows.h' file not found
[+] CC contrib/untgz/untgz.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -..
contrib/untgz/untgz.c:277,7: warning: implicit declaration of function 'chmod'..
contrib/untgz/untgz.c:341,7: warning: implicit declaration of function 'mkdir'..
contrib/untgz/untgz.c:659,11: warning: incompatible pointer types assigning to..
contrib/untgz/untgz.c:665,18: warning: incompatible pointer types passing 'gzF..
[+] CC examples/enough.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./i..
[+] CC examples/fitblk.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./i..
[+] CC examples/gun.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./incl..
[+] CC examples/gzappend.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I...
[+] CC examples/gzjoin.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./i..
[+] CC examples/gzlog.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./in..
[+] CC examples/gznorm.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./i..
[+] CC examples/zpipe.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./in..
[+] CC examples/zran.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./inc..
[+] CC test/example.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./incl..
[+] CC test/infcover.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./inc..
[+] CC test/minigzip.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./inc..
[+] CC adler32.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC compress.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC crc32.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC deflate.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC gzclose.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC gzlib.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC gzread.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC gzwrite.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC infback.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC inffast.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC inflate.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC inftrees.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC trees.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC uncompr.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC ztest19.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] CC zutil.c -I/usr/lib/llvm-14/lib/clang/14.0.6/include -I. -I./include
[+] Building definitions...
[+] Building the callgraphs...
[+] Building the constants table...
[+] Creating indexes...

4 warning(s), 0 error(s), 5 fatal error(s)
```
I also tested on Windows and failed, will keep trying and find more testcases. Hope this help.